### PR TITLE
Bump next-google-fonts

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -14,7 +14,7 @@
     "@mdx-js/loader": "1.5.8",
     "@next/mdx": "9.3.3",
     "next": "9.3.3",
-    "next-google-fonts": "0.1.0",
+    "next-google-fonts": "1.0.0",
     "prism-react-renderer": "1.0.2",
     "raam": "^0.2.0",
     "react": "16.13.1",

--- a/packages/docs/src/components/head.tsx
+++ b/packages/docs/src/components/head.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import * as React from "react";
 import NextHead from "next/head";
-import { GoogleFonts } from "next-google-fonts";
+import GoogleFonts from "next-google-fonts";
 import { jsx, useThemeUI } from "theme-ui";
 import config from "../config";
 
@@ -10,7 +10,7 @@ const Head: React.FC = () => {
 
   return (
     <React.Fragment>
-      <GoogleFonts />
+      <GoogleFonts href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" />
       <NextHead>
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/packages/docs/src/pages/_app.tsx
+++ b/packages/docs/src/pages/_app.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { AppProps } from "next/app";
-import { GoogleFontsProvider } from "next-google-fonts";
 import { ThemeProvider } from "theme-ui";
 import Code from "../components/code";
 import Layout from "../components/layout";
@@ -13,9 +12,7 @@ const RaamApp = ({ Component, pageProps }: AppProps) => (
     // @ts-ignore
     components={{ wrapper: Layout, code: Code, ...headings }}
   >
-    <GoogleFontsProvider href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
-      <Component {...pageProps} />
-    </GoogleFontsProvider>
+    <Component {...pageProps} />
   </ThemeProvider>
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6380,6 +6380,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-deep-equal@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
 fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
@@ -9908,10 +9913,12 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-next-google-fonts@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/next-google-fonts/-/next-google-fonts-0.1.0.tgz#aa8aa910464a59847b478279d4130e50a76d60aa"
-  integrity sha512-X1RKvp8F61RrDW638ncaOSSyPdEpdz4OukveXaS+S8hfEksAdYUmpfJSi5I5rfJhpXqkKau4iSnGzdr2BmKHxg==
+next-google-fonts@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-google-fonts/-/next-google-fonts-1.0.0.tgz#03e38607f229fed69ce0f131ac61659b13f8cf98"
+  integrity sha512-IMt0g7iaTt2koeSbmRu6A0zh22ESwoHCzSyJbpl8xeEjoqX1Tt8WfgIStbneMTwO3cT/wwPK9M4SK9UZofXNrA==
+  dependencies:
+    swr "0.2.2"
 
 next-tick@~1.0.0:
   version "1.0.0"
@@ -13996,6 +14003,13 @@ svgo@^1.0.0:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+swr@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.2.2.tgz#6e1b3e5c0e545c4fdb36ae3aa38cd94d0f9a88b7"
+  integrity sha512-D/z+PTUchZhoUA0tNC8TNJivf7Hc61WPxbUdXPi+VxRloddWYNP1ZicaEgyAph42ZnKl1L7twcZr4q6d0UMXcg==
+  dependencies:
+    fast-deep-equal "2.0.1"
 
 symbol-observable@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
To the latest version: https://github.com/joe-bell/next-google-fonts/releases/tag/v1.0.0