### PR TITLE
Avoid rendering empty children

### DIFF
--- a/packages/raam/src/flex.tsx
+++ b/packages/raam/src/flex.tsx
@@ -55,6 +55,7 @@ export const Flex = React.forwardRef<any, FlexProps>(
           __css={{
             position: "relative",
           }}
+          key={i}
           index={i}
           flexParent={{ flexWrap, flexDirection }}
           gapTop={gap}

--- a/packages/raam/src/flex.tsx
+++ b/packages/raam/src/flex.tsx
@@ -49,7 +49,7 @@ export const Flex = React.forwardRef<any, FlexProps>(
       flexWrap={flexWrap}
       {...props}
     >
-      {React.Children.map(children, (child, i) => (
+      {React.Children.toArray(children).map((child, i) => (
         <Box
           as={determineChild(as)}
           __css={{


### PR DESCRIPTION
This PR fixes a bug that causes unwanted additional space when conditionally rendering a child component of the Flex component (and hence all the Raam components).

This sandbox shows the bug causing additional space between the second and third paragraphs: https://codesandbox.io/s/raam-bug-qucx5

The fix simply calls `toArray` on the children, which has the side-effect of filtering out falsy components.

Let me know what you think. Thanks for creating this great library!